### PR TITLE
prettier - eslint and conifg

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,9 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Adding a prettierrc will trigger most editor
+  // plugins to use prettier. While this is not needed
+  // for filse linted by eslint, it is needed for other files,
+  // such as json, yaml, etc…
+};


### PR DESCRIPTION
Added the plugins needed to run `prettier` as part of `eslint`.

Adding a `.prettierrc.js` file will trigger the prettier plugin in most editors. While this is not needed for files processed by eslint, this will use `prettier` for all other files, e.g. `md`, `json`, `yaml`, …